### PR TITLE
Fix: crash with isolated partitions

### DIFF
--- a/faust/__init__.py
+++ b/faust/__init__.py
@@ -24,7 +24,7 @@ import typing
 
 from typing import Any, Mapping, NamedTuple, Optional, Sequence, Tuple
 
-__version__ = '1.12.2'
+__version__ = '1.12.3'
 __author__ = 'Robinhood Markets, Inc.'
 __contact__ = 'contact@fauststream.com'
 __homepage__ = 'http://faust.readthedocs.io/'

--- a/faust/topics.py
+++ b/faust/topics.py
@@ -475,6 +475,16 @@ class Topic(SerializedChannel, TopicT):
                     retention=self.retention,
                 )
 
+    def on_stop_iteration(self) -> None:
+         """Signal that iteration over this channel was stopped.
+         Tip:
+             Remember to call ``super`` when overriding this method.
+         """
+         super().on_stop_iteration()
+         if self.active_partitions is not None:
+             # Remove topics for isolated partitions from the Conductor.
+             self.app.topics.discard(cast(TopicT, self))
+
     def __aiter__(self) -> ChannelT:
         if self.is_iterator:
             return self


### PR DESCRIPTION
* Remove topics with active_partitions from the Conductor when iteration ends (https://github.com/faust-streaming/faust/pull/531)